### PR TITLE
bugfix for filter.parent.offspring, was attempting to order using a d…

### DIFF
--- a/R/gl.filter.parent.offspring.r
+++ b/R/gl.filter.parent.offspring.r
@@ -251,7 +251,7 @@ gl.filter.parent.offspring <- function(x,
         ), 4)
     }
     # ordering by number of outliers
-    outliers <- outliers[order(outliers, decreasing = T), ]
+    outliers <- outliers[order(outliers$Outlier, decreasing = T), ]
     # removing duplicated values
     outliers <- outliers[!duplicated(outliers), ]
     # removing NAs


### PR DESCRIPTION
…ataframe and not the relevant field

Bugfix for when running the following code:
```r
gl = platypus.gl
class(gl) = "genlight"
out <- gl.filter.parent.offspring(gl)
```
Was causing error:
Error in xtfrm.data.frame(x) : cannot xtfrm data frames
