### PR TITLE
fix bug in gl.grm.network: handle empty edges when no pair clears kinship.threshold

### DIFF
--- a/R/gl.grm.network.r
+++ b/R/gl.grm.network.r
@@ -342,16 +342,29 @@ gl.grm.network <- function(G,
   # Rebuild the factor
   plotcord$pop <- factor(plotcord$pop, levels = new_levels)
   
-  breaks <- pretty(round(seq(min(edges$size),
-                      max(edges$size),
-                      0.1),1),4)
-  
+  if (nrow(edges) > 0) {
+    breaks <- pretty(round(seq(min(edges$size),
+                        max(edges$size),
+                        0.1),1),4)
+  } else {
+    if (verbose >= 1) {
+      cat(warn(paste0(
+        "  No pairs of individuals have a kinship value at or above the",
+        " kinship.threshold (", kinship.threshold, "); the network is shown",
+        " with nodes only and no links.\n"
+      )))
+    }
+    breaks <- 0
+  }
+
   if(categorise){
-    edges$cat <- NULL
-    edges[edges$size >=0.3,"cat"] <- "Same Individual" 
-    edges[edges$size >=0.2 & edges$size < 0.3,"cat"] <-"Full Siblings\nParent-Offspring"
-    edges[edges$size >=0.1 & edges$size < 0.2,"cat"] <-"Half Siblings"
-    edges[edges$size >=0.038 & edges$size < 0.1,"cat"] <-"First Cousins"
+    edges$cat <- rep(NA_character_, nrow(edges))
+    if (nrow(edges) > 0) {
+      edges[edges$size >=0.3,"cat"] <- "Same Individual"
+      edges[edges$size >=0.2 & edges$size < 0.3,"cat"] <-"Full Siblings\nParent-Offspring"
+      edges[edges$size >=0.1 & edges$size < 0.2,"cat"] <-"Half Siblings"
+      edges[edges$size >=0.038 & edges$size < 0.1,"cat"] <-"First Cousins"
+    }
 
 p1 <-
   ggplot() + 


### PR DESCRIPTION
## Summary
- `gl.grm.network` crashed with `'from' must be a finite number` when no pair of individuals had a kinship value at or above `kinship.threshold`. With zero edges, `edges` had zero rows and `seq(min(edges$size), max(edges$size), 0.1)` got `Inf`/`-Inf`.
- A second latent crash sat behind it: the `categorise = TRUE` branch did `edges$cat <- NULL` then assigned categories by row index, which errors on a zero-row data frame.

## Fix
- Compute `breaks` only when `edges` has rows; otherwise emit an informative message and render a nodes-only network.
- Pre-build the `cat` column with `rep(NA_character_, nrow(edges))` and guard the per-category assignments so the categorise branch works with or without edges.

## Test plan
- [x] `gl.grm.network(G, x, categorise = TRUE, kinship.threshold = 0.32)` with no qualifying pair now returns instead of erroring
- [x] `categorise = FALSE` with no edges works
- [x] `categorise = TRUE/FALSE` with edges (threshold 0.05, 0.125) still works